### PR TITLE
Fix: pinMessage endpoint fixed

### DIFF
--- a/src/endpoints/chat/chat.endpoint.ts
+++ b/src/endpoints/chat/chat.endpoint.ts
@@ -92,7 +92,7 @@ export class ChatEndpoint extends BaseEndpoint {
       endpoint: `api/v2/channels/${channel}/pinned-message`,
       method: 'post',
       options: {
-        body: JSON.stringify(body),
+        body: body,
       },
     })
     if (response.status !== 200)


### PR DESCRIPTION
pinMessage endpoint currently unnecesarily stringifies the body causing 422 error with kick. 

Removed this which fixes the endpoint